### PR TITLE
Update alter_primary_key.go

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -233,6 +233,14 @@ func (p *planner) AlterPrimaryKey(
 	// * don't store or index all columns in the new primary key.
 	shouldRewriteIndex := func(idx *descpb.IndexDescriptor) bool {
 		shouldRewrite := false
+		for _,exColID:=range idx.ExtraColumnIDs{
+			if col, err := tableDesc.FindColumnByID(exColID);err!=nil{
+				break;
+			}else if col.Hidden && tableDesc.PrimaryIndex.ContainsColumnID(col.ID){
+				shouldRewrite=true;
+				break;
+			}
+		}
 		for _, colID := range newPrimaryIndexDesc.ColumnIDs {
 			if !idx.ContainsColumnID(colID) {
 				shouldRewrite = true


### PR DESCRIPTION
to fix
Crash when deleting a row on a table with a unique index and similar PK #54629